### PR TITLE
Add test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Output:
 
 ```
 Country of +18045551234: US
-Country of 8045551234: US
+Country of 8045551234: ZZ
 Country of +447400555123: GB
 Country of 07400555123: ZZ
 ```

--- a/test.lua
+++ b/test.lua
@@ -1,0 +1,32 @@
+phonenumber = require 'luaphonenumber'
+
+-- Test `parse`
+local pn = phonenumber.parse( "+18045551234", "us", "en", "US" )
+assert(pn.E164 == '+18045551234')
+assert(pn.RFC3966 == 'tel:+1-804-555-1234')
+assert(pn.INTERNATIONAL == '+1 804-555-1234')
+assert(pn.NATIONAL == '(804) 555-1234')
+assert(pn.country == 'US')
+assert(pn.location == 'Virginia')
+assert(pn.type == 'FIXED_LINE_OR_MOBILE')
+
+-- Test `format`
+assert(phonenumber.format( "+18045551234", "us", "E164" ) == '+18045551234')
+assert(phonenumber.format( "+18045551234", "us", "RFC3966" ) == 'tel:+1-804-555-1234')
+assert(phonenumber.format( "+18045551234", "us", "INTERNATIONAL" ) == '+1 804-555-1234')
+assert(phonenumber.format( "+18045551234", "us", "NATIONAL" ) == '(804) 555-1234')
+
+-- Test `get_country`
+assert(phonenumber.get_country( "+18045551234", "us" ) == 'US')
+assert(phonenumber.get_country( "8045551234", "us" ) == 'ZZ')
+assert(phonenumber.get_country( "+447400555123", "us" ) == 'GB')
+assert(phonenumber.get_country( "07400555123", "us" ) == 'ZZ')
+
+-- Test `get_location`
+assert(phonenumber.get_location( "+18045551234", "us", "en", "US" ) == 'Virginia')
+assert(phonenumber.get_location( "+442085551234", "gb", "en", "US" ) == 'London')
+
+-- Test `get_type`
+assert(phonenumber.get_type( "+18045551234", "us" ) == 'FIXED_LINE_OR_MOBILE')
+assert(phonenumber.get_type( "+442085551234", "gb" ) == 'FIXED_LINE')
+assert(phonenumber.get_type( "+40740555123", "ro" ) == 'MOBILE')


### PR DESCRIPTION
This script is not intended to do a very thorough test of luaphonenumber; it's more like a 'smoke test' which can be used after building a binary. It is based on the code samples in README.md.

Speaking of which, running the test script revealed that the output for one of the code samples in README.md was not the same as shown.

Regarding the test results which were different from README.md: I tested this on a PopOS (Ubuntu-like) Linux system. This is the version of libphonenumber which was used for testing:

```
libphonenumber8/jammy,now 8.12.44-1 amd64
```